### PR TITLE
fix: duplicate buildsteps with the same name

### DIFF
--- a/jx-build-templates/templates/knative-deploy-buildtemplate.yaml
+++ b/jx-build-templates/templates/knative-deploy-buildtemplate.yaml
@@ -14,7 +14,7 @@ spec:
     - --client-only
     - http://chartmuseum.jenkins-x.io
     image: jenkinsxio/builder-base:0.0.623
-    name: deploy
+    name: "helm-init"
     resources:
       limits:
         cpu: 200m
@@ -29,7 +29,7 @@ spec:
     - jenkins-x
     - http://chartmuseum.jenkins-x.io
     image: jenkinsxio/builder-base:0.0.623
-    name: deploy
+    name: "helm-add-repo"
     resources:
       limits:
         cpu: 200m


### PR DESCRIPTION
message: 'Pod "ffd4a0d9-dc7c-11e8-94c9-0a580a300553-24gzl" is invalid: [spec.initContainers[2].name:
        Duplicate value: "build-step-deploy", spec.initContainers[3].name: Duplicate
        value: "build-step-deploy"]'