### PR TITLE
Reduce CPU request to .5

### DIFF
--- a/jx-build-templates/templates/jenkins-base-buildtemplate.yaml
+++ b/jx-build-templates/templates/jenkins-base-buildtemplate.yaml
@@ -29,7 +29,7 @@ spec:
         cpu: 3
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "0.5"
         memory: 1Gi
     volumeMounts:
     - mountPath: /home/jenkins/.docker

--- a/jx-build-templates/templates/jenkins-csharp-buildtemplate.yaml
+++ b/jx-build-templates/templates/jenkins-csharp-buildtemplate.yaml
@@ -29,7 +29,7 @@ spec:
         cpu: 3
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "0.5"
         memory: 1Gi
     volumeMounts:
     - mountPath: /home/jenkins/.docker

--- a/jx-build-templates/templates/jenkins-cwp-buildtemplate.yaml
+++ b/jx-build-templates/templates/jenkins-cwp-buildtemplate.yaml
@@ -29,7 +29,7 @@ spec:
         cpu: 3
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "0.5"
         memory: 1Gi
     volumeMounts:
     - mountPath: /home/jenkins/.docker

--- a/jx-build-templates/templates/jenkins-filerunner-buildtemplate.yaml
+++ b/jx-build-templates/templates/jenkins-filerunner-buildtemplate.yaml
@@ -29,7 +29,7 @@ spec:
         cpu: 3
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "0.5"
         memory: 1Gi
     volumeMounts:
     - mountPath: /home/jenkins/.docker

--- a/jx-build-templates/templates/jenkins-go-buildtemplate.yaml
+++ b/jx-build-templates/templates/jenkins-go-buildtemplate.yaml
@@ -32,7 +32,7 @@ spec:
         cpu: 3
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "0.5"
         memory: 1Gi
     volumeMounts:
     - mountPath: /home/jenkins/.docker

--- a/jx-build-templates/templates/jenkins-gradle-buildtemplate.yaml
+++ b/jx-build-templates/templates/jenkins-gradle-buildtemplate.yaml
@@ -29,7 +29,7 @@ spec:
         cpu: 3
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "0.5"
         memory: 1Gi
     volumeMounts:
     - mountPath: /home/jenkins/.docker

--- a/jx-build-templates/templates/jenkins-javascript-buildtemplate.yaml
+++ b/jx-build-templates/templates/jenkins-javascript-buildtemplate.yaml
@@ -29,7 +29,7 @@ spec:
         cpu: 3
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "0.5"
         memory: 1Gi
     volumeMounts:
     - mountPath: /home/jenkins/.docker

--- a/jx-build-templates/templates/jenkins-jenkins-buildtemplate.yaml
+++ b/jx-build-templates/templates/jenkins-jenkins-buildtemplate.yaml
@@ -29,7 +29,7 @@ spec:
         cpu: 3
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "0.5"
         memory: 1Gi
     volumeMounts:
     - mountPath: /home/jenkins/.docker

--- a/jx-build-templates/templates/jenkins-maven-buildtemplate.yaml
+++ b/jx-build-templates/templates/jenkins-maven-buildtemplate.yaml
@@ -29,7 +29,7 @@ spec:
         cpu: 3
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "0.5"
         memory: 1Gi
     volumeMounts:
     - mountPath: /home/jenkins/.docker

--- a/jx-build-templates/templates/jenkins-python-buildtemplate.yaml
+++ b/jx-build-templates/templates/jenkins-python-buildtemplate.yaml
@@ -29,7 +29,7 @@ spec:
         cpu: 3
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "0.5"
         memory: 1Gi
     volumeMounts:
     - mountPath: /home/jenkins/.docker

--- a/jx-build-templates/templates/jenkins-rust-buildtemplate.yaml
+++ b/jx-build-templates/templates/jenkins-rust-buildtemplate.yaml
@@ -29,7 +29,7 @@ spec:
         cpu: 3
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "0.5"
         memory: 1Gi
     volumeMounts:
     - mountPath: /home/jenkins/.docker

--- a/jx-build-templates/templates/jenkins-scala-buildtemplate.yaml
+++ b/jx-build-templates/templates/jenkins-scala-buildtemplate.yaml
@@ -29,7 +29,7 @@ spec:
         cpu: 3
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "0.5"
         memory: 1Gi
     volumeMounts:
     - mountPath: /home/jenkins/.docker

--- a/jx-build-templates/templates/jenkins-test-buildtemplate.yaml
+++ b/jx-build-templates/templates/jenkins-test-buildtemplate.yaml
@@ -29,7 +29,7 @@ spec:
         cpu: 3
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "0.5"
         memory: 1Gi
     volumeMounts:
     - mountPath: /home/jenkins/.docker


### PR DESCRIPTION
On a GKE cluster with 3–5 nodes of machine type *n1-standard-1 (1 vCPU, 3.75 GB memory)*, Prow builds flat-out did not work: even when the cluster was still at 3 nodes, GKE refused to scale it up, apparently because the CPU request plus overhead was greater than a new node would claim to handle. I was able to fix this on the fly by

```bash
kubectl edit buildtemplates.build.knative.dev jenkins-maven 
```

so this just codifies that change. (Extended to all build templates; I am assuming Maven is one of the more resource-hungry.) My reasoning is that it is better to let the build run on a shared node and perhaps run a bit more slowly than you would prefer, than to risk having it not run at all and leave the user scratching their head. The default memory request did not seem to pose an issue so I left it alone.

(I was not watching closely, but I did not notice any particularly slowness in the build itself—only in the time pulling images onto new nodes, and waiting for Prow to wake up and trigger things. My intuition is that a build like this would be mostly constrained by network I/O, not CPU.)

Note that the runtime pods display `500m` rather than `"0.5"`. Not sure which form is preferred in sources.